### PR TITLE
ci: add Snapcrafters CI

### DIFF
--- a/.github/workflows/promote-to-stable.yaml
+++ b/.github/workflows/promote-to-stable.yaml
@@ -1,0 +1,25 @@
+name: Promote
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  issues: write
+
+jobs:
+  promote:
+    name: ⬆️ Promote to stable
+    environment: "Candidate Branch"
+    runs-on: ubuntu-latest
+    if: |
+      ( !github.event.issue.pull_request )
+      && contains(github.event.comment.body, '/promote ')
+      && contains(github.event.*.labels.*.name, 'testing')
+    steps:
+      - name: ⬆️ Promote to stable
+        uses: snapcrafters/ci/promote-to-stable@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          store-token: ${{ secrets.SNAP_STORE }}

--- a/.github/workflows/release-to-candidate.yaml
+++ b/.github/workflows/release-to-candidate.yaml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  # Run the workflow each time new commits are pushed to the candidate branch.
+  push:
+    branches: [ "candidate" ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  get-architectures:
+    name: 🖥 Get snap architectures
+    runs-on: ubuntu-latest
+    outputs:
+      architectures: ${{ steps.get-architectures.outputs.architectures }}
+      architectures-list: ${{ steps.get-architectures.outputs.architectures-list }}
+    steps:
+      - name: 🖥 Get snap architectures
+        id: get-architectures
+        uses: snapcrafters/ci/get-architectures@main
+
+  release:
+    name: 🚢 Release to latest/candidate
+    needs: get-architectures
+    runs-on: ubuntu-latest
+    environment: "Candidate Branch"
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture: ${{ fromJSON(needs.get-architectures.outputs.architectures-list) }}
+    steps:
+      - name: 🚢 Release to latest/candidate
+        uses: snapcrafters/ci/release-to-candidate@main
+        with:
+          channel: latest/candidate
+          architecture: ${{ matrix.architecture }}
+          launchpad-token: ${{ secrets.LP_BUILD_SECRET }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          store-token: ${{ secrets.SNAP_STORE }}
+
+  call-for-testing:
+    name: 📣 Create call for testing
+    needs: [release, get-architectures]
+    environment: "Candidate Branch"
+    runs-on: ubuntu-latest
+    outputs:
+      issue-number: ${{ steps.issue.outputs.issue-number }}
+    steps:
+      - name: 📣 Create call for testing
+        id: issue
+        uses: snapcrafters/ci/call-for-testing@main
+        with:
+          architectures: ${{ needs.get-architectures.outputs.architectures }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-version-with-upstream.yaml
+++ b/.github/workflows/sync-version-with-upstream.yaml
@@ -1,0 +1,31 @@
+name: Update
+
+on:
+  # Runs at 10:00 UTC every day
+  schedule:
+    - cron:  '0 10 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: 🔄 Sync version with upstream
+    environment: "Candidate Branch"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: 🔄 Sync version with upstream
+        uses: snapcrafters/ci/sync-version@main
+        with:
+          branch: candidate
+          token: ${{ secrets.GITHUB_TOKEN }}
+          update-script: |
+            version=$(
+              curl -sL https://api.github.com/repos/python/black/releases/latest | jq -r .tag_name
+            )
+            sed -i 's/^\(version: \).*$/\1'"${version}"'/' snap/snapcraft.yaml

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: black
 base: core20
+version: 22.8.0
 summary: The uncompromising Python code formatter
 description: |
   Black is the uncompromising Python code formatter. By using it, you
@@ -14,6 +15,14 @@ description: |
 confinement: strict
 adopt-info: black
 
+architectures:
+  - amd64
+  - arm64
+  - armhf
+  - i386
+  - ppc64el
+  - s390x
+
 apps:
   black:
     command: bin/black
@@ -27,6 +36,7 @@ apps:
 parts:
   black:
     source: https://github.com/python/black.git
+    source-tag: $SNAPCRAFT_PROJECT_VERSION
     plugin: python
     override-pull: |
       snapcraftctl pull


### PR DESCRIPTION
This adds CI from Snapcrafters that will:

1. Automatically update snapcraft.yaml upon a new upstream release
2. Use remote build on Launchpad to build on pushes to `candidate`
3. Upload and publish those to `latest/candidate`
4. Create a call for testing issue

It does require some configuration of the repository though:

1. A `SNAP_STORE` secret with access to the `black` snap on the `latest/candidate` and `latest/stable` channels
2. An `LP_BUILD_SECRET` secret that can create builds on Launchpad.
3. Creating a `candidate` branch in the repository, which the CI will update.

The build secret can be created with the following Python code:

```
import launchpadlib.launchpad
launchpadlib.launchpad.Launchpad.login_with(
    credentials_file="black-build.cred",
    application_name="snapcrafters-ci",
    service_root="production",
    version="devel"
)
```

(The contents of the build secret will be placed in `black-build.cred`)